### PR TITLE
fix: error updating the now playing widget when idle

### DIFF
--- a/src/spotify-web.ts
+++ b/src/spotify-web.ts
@@ -41,7 +41,15 @@ export function formatTrackDetails(track: PlaylistItemWithAudioFeatures) {
 
 export async function updateNowPlayingWidget(elemNowPlayingWidget: Element) {
   const accessToken = await getAccessToken();
-  const currentTrack = await getCurrentlyPlayingTrack(accessToken);
+
+  let currentTrack: Track;
+  try {
+    currentTrack = await getCurrentlyPlayingTrack(accessToken);
+  } catch {
+    console.info("Unable to retrieve the currently playing track.");
+    return;
+  }
+
   const trackAudioFeatures = await getTrackAudioFeatures(
     accessToken,
     currentTrack.id,


### PR DESCRIPTION
Prevents the now playing widget from updating if there's nothing playing.